### PR TITLE
fix: show the entire chat history item

### DIFF
--- a/src/components/inputBar.tsx
+++ b/src/components/inputBar.tsx
@@ -90,7 +90,7 @@ export default function InputBar({
             setInputValue("");
             for await (const chunk of aiReplayStream) {
               setChatHistory((h) => {
-                h[h.length - 1].text = chunk;
+                h[h.length - 1].text += chunk;
                 return [...h];
               });
               lastMsgRef.current?.scrollIntoView({ behavior: "smooth" });


### PR DESCRIPTION
before:

![image](https://github.com/user-attachments/assets/5fc07e88-9024-4157-a27e-093d9195aee4)


after:

![image](https://github.com/user-attachments/assets/932825bf-2432-4ba2-9834-a642b5cd2042)
